### PR TITLE
Artifact name fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired by and modeled after the
 Add the following to your project.clj:
 
 ```clj
-[clojsc/ring-xml "0.1.0"]
+[clojusc/ring-xml "0.1.0"]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Inspired by and modeled after the
 Add the following to your project.clj:
 
 ```clj
-[clojsc/ring-xml "0.0.6"]
+[clojsc/ring-xml "0.1.0"]
 ```
 
 


### PR DESCRIPTION
I could only find the jar published under the `clojusc` name and `0.1.0` appears to be the most recent published version.