### PR TITLE
Streaming xml

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clojusc/ring-xml "0.1.0"
+(defproject clojusc/ring-xml "0.1.1"
   :description "Ring middleware for XML requests and responses."
   :url "https://github.com/clojusc/ring-xml"
   :license {:name "The MIT License"

--- a/src/clojusc/ring/xml.clj
+++ b/src/clojusc/ring/xml.clj
@@ -3,7 +3,8 @@
             [clojure.string :as string]
             [clojure.data.xml :as xml]
             [ring.util.response :as ring])
-  (:import [javax.xml.stream XMLStreamException]))
+  (:import [javax.xml.stream XMLStreamException]
+           [java.io InputStream]))
 
 (defn xml-request?
   "Determine if the incoming collection represents an XML request."
@@ -16,8 +17,9 @@
   [request]
   (if (xml-request? request)
     (if-let [body (:body request)]
-      (if-not (coll? body)
-        body))
+      (cond
+       (instance? InputStream body) (slurp body)
+       (not (coll? body)) body))
     nil))
 
 (defn ->xml [data options]

--- a/test/clojusc/ring/test/xml.clj
+++ b/test/clojusc/ring/test/xml.clj
@@ -28,6 +28,9 @@
 (def request-4 {:content-type "text/plain"
                 :body "stuff"})
 
+(def request-5 {:content-type "application/xml"
+                :body (io/string-input-stream str-data-xml)})
+
 (deftest test->xml
   (testing "Using elements ..."
     (is (= str-empty-xml (ring-xml/->xml empty-xml {:elements true})))
@@ -49,7 +52,11 @@
   (let [handler (ring-xml/wrap-xml-request identity)]
     (testing "XML Body"
       (let [response (handler request-1)]
-        (is (= empty-xml (:body response)))))))
+        (is (= empty-xml (:body response)))))
+    (testing "Streaming XML Body"
+      (let [streamed-response (handler request-5)]
+        (is (= (xml/parse-str str-data-xml)
+               (:body streamed-response)))))))
 
 (deftest test-xml-response
   (testing "No options"


### PR DESCRIPTION
@oubiwann I was experiencing some issues with this lib and using Jetty/Ring. It would blow up complaining:

```
java.lang.ClassCastException: org.eclipse.jetty.server.HttpInputOverHTTP cannot be cast to java.lang.String
```

If there's a better way to go about this (or I'm doing something really stupid) I'm all ears. I was basically copying a small bit from https://github.com/ring-clojure/ring-json/blob/master/src/ring/middleware/json.clj#L11-L19

Thanks! :) 